### PR TITLE
Reduce HTTP calls on all() and allWithGenerators()

### DIFF
--- a/src/Builders/BaseBuilder.php
+++ b/src/Builders/BaseBuilder.php
@@ -154,9 +154,9 @@ class BaseBuilder
 		    
             	$response->getBody()->close();
 
-		// If we got fewer items returned than requested, it means we reached page limit
-		// Using min() to ensure $pageSize > 1000 doesn't cause infinite loops
-		// Since e-conomic max pageSize is 1000.
+                // If we got fewer items returned than requested, it means we reached page limit
+                // Using min() to ensure $pageSize > 1000 doesn't cause infinite loops
+                // Since e-conomic max pageSize is 1000.
                 if (count($fetchedItems) < min($pageSize, 1000)) {
                     $hasMore = false;
 
@@ -223,9 +223,9 @@ class BaseBuilder
 
                 $items = $this->parseResponse($responseData, $items);
 
-		// If we got fewer items returned than requested, it means we reached page limit
-		// Using min() to ensure $pageSize > 1000 doesn't cause infinite loops
-		// Since e-conomic max pageSize is 1000.
+                // If we got fewer items returned than requested, it means we reached page limit
+                // Using min() to ensure $pageSize > 1000 doesn't cause infinite loops
+                // Since e-conomic max pageSize is 1000.
                 if (count($responseData->collection) < min($pageSize, 1000)) {
                     $hasMore = false;
 

--- a/src/Builders/BaseBuilder.php
+++ b/src/Builders/BaseBuilder.php
@@ -154,7 +154,10 @@ class BaseBuilder
 		    
             	$response->getBody()->close();
 
-                if (count($fetchedItems) === 0) {
+		// If we got fewer items returned than requested, it means we reached page limit
+		// Using min() to ensure $pageSize > 1000 doesn't cause infinite loops
+		// Since e-conomic max pageSize is 1000.
+                if (count($fetchedItems) < min($pageSize, 1000)) {
                     $hasMore = false;
 
                     break;
@@ -216,12 +219,14 @@ class BaseBuilder
 
         return $this->request->handleWithExceptions(function () use (&$hasMore, $pageSize, &$items, &$page, $urlQuery) {
             while ($hasMore) {
-
                 $responseData = $this->getRequest($page, $pageSize, $urlQuery);
 
                 $items = $this->parseResponse($responseData, $items);
 
-                if (count($responseData->collection) === 0) {
+		// If we got fewer items returned than requested, it means we reached page limit
+		// Using min() to ensure $pageSize > 1000 doesn't cause infinite loops
+		// Since e-conomic max pageSize is 1000.
+                if (count($responseData->collection) < min($pageSize, 1000)) {
                     $hasMore = false;
 
                     break;


### PR DESCRIPTION
**BEFORE**
![CleanShot 2023-05-26 at 18 06 29](https://github.com/Rackbeat/laravel-economic/assets/2689341/e63c541e-8802-4799-b73d-e55dbd4b26c1)



**AFTER**
![CleanShot 2023-05-26 at 18 07 27](https://github.com/Rackbeat/laravel-economic/assets/2689341/c2a6f318-1c81-458e-9aa0-ff968ef88577)

Notice it doesn't do extra calls for layouts endpoint, because there are fewer than 1000 layouts. Previously it would.