### PR TITLE
Fix currency price endpoint for wild product numbers

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -2,6 +2,7 @@
 
 namespace LasseRafn\Economic\Models;
 
+use LasseRafn\Economic\Builders\ProductBuilder;
 use LasseRafn\Economic\Builders\ProductCurrencyPriceBuilder;
 use LasseRafn\Economic\Utils\Model;
 
@@ -50,6 +51,9 @@ class Product extends Model
      */
     public function currencyPrices()
     {
-        return new ProductCurrencyPriceBuilder($this->request, $this->productNumber);
+        return new ProductCurrencyPriceBuilder(
+            $this->request, 
+            (new ProductBuilder($this->request))->encode($this->productNumber)
+        );
     }
 }


### PR DESCRIPTION
If client has product number = `??UA.JPR1.NC.308.24`, this will currently call the products endpoint, which will load a ton of products rather than currency prices.

This change transforms the number to e-co format first, fixing the issue 😇 

In turn, it loads ALL products into memory (the integration calls currencyPrices()->all()), which causes memory to go wild (https://rackbeat.sentry.io/issues/4250099200/?alert_rule_id=988926&alert_timestamp=1686737663180&alert_type=email&environment=production&project=2325368&referrer=alert_email)

(Agreement 8110 has this issue)